### PR TITLE
adds styles for figure and figcaption.

### DIFF
--- a/concrete.css
+++ b/concrete.css
@@ -79,7 +79,7 @@ figcaption {
   text-align: right; /* 1 */
   font-size: 1.6rem; /* 2 */
   border-bottom: .2rem solid var(--fg); /* 3 */
-  padding-bottom: 1rem; /* 4 */
+  padding-bottom: .2rem; /* 4 */
 }
 
 /**

--- a/concrete.css
+++ b/concrete.css
@@ -69,17 +69,19 @@ a {
  */
 figure {
   margin: 0; /* 1 */
-  border-bottom: .2rem solid var(--fg); /* 2 */
-  padding-bottom: 1rem; /* 3 */
 }
 
 /**
  * 1. Right-align text 
  * 2. Make figure caption a little smaller than normal text.
+ * 3. Add border at bottom.
+ * 4. Add spacing after the element.
  */
 figcaption {
   text-align: right; /* 1 */
   font-size: 1.6rem; /* 2 */
+  border-bottom: .2rem solid var(--fg); /* 3 */
+  padding-bottom: 1rem; /* 4 */
 }
 
 /**

--- a/concrete.css
+++ b/concrete.css
@@ -64,8 +64,6 @@ a {
 
 /**
  * 1. Stretch figure to full width of the section.
- * 2. Add border at bottom.
- * 3. Add spacing after the element.
  */
 figure {
   margin: 0; /* 1 */

--- a/concrete.css
+++ b/concrete.css
@@ -63,6 +63,26 @@ a {
 }
 
 /**
+ * 1. Stretch figure to full width of the section.
+ * 2. Add border at bottom.
+ * 3. Add spacing after the element.
+ */
+figure {
+  margin: 0; /* 1 */
+  border-bottom: .2rem solid var(--fg); /* 2 */
+  padding-bottom: 1rem; /* 3 */
+}
+
+/**
+ * 1. Right-align text 
+ * 2. Make figure caption a little smaller than normal text.
+ */
+figcaption {
+  text-align: right; /* 1 */
+  font-size: 1.6rem; /* 2 */
+}
+
+/**
  * 1. Set the max width of images to 100%, so that they don't overflow.
  * 2. Set the height of images relative to their width.
  */

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ import 'concrete.css'</code></pre>
 
     <section>
       <h2>Figures</h2>
-      <p>Simply add a figure with a caption, and voilà !</p>
+      <p>Adding a caption to a figure is as simple as it sounds.</p>
       <figure>
         <img alt="Placeholder" src="https://picsum.photos/640/480?grayscale">
         <figcaption>This is the right-aligned caption for the figure. This example is very long to demonstrate at least one line-break.</figcaption>

--- a/index.html
+++ b/index.html
@@ -176,6 +176,15 @@ import 'concrete.css'</code></pre>
     </section>
 
     <section>
+      <h2>Figures</h2>
+      <p>Simply add a figure with a caption, and voilà !</p>
+      <figure>
+        <img alt="Placeholder" src="https://picsum.photos/640/480?grayscale">
+        <figcaption>This is the right-aligned caption for the figure. This example is very long to demonstrate at least one line-break.</figcaption>
+      </figure>      
+    </section>    
+
+    <section>
       <h2>Lists</h2>
       <p>The concrete list is simply marked by a square.</p>
       <ul>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,8 @@ import 'concrete.css'</code></pre>
       <ul>
         <li>left-click and "View Page Source"</li>
         <li>left-click and "Inspect"</li>
-        <li>read the <a href="https://github.com/louismerlin/concrete.css/blob/main/index.html">index.html</a> on GitHub</li>
+        <li>read the <a href="https://github.com/louismerlin/concrete.css/blob/main/index.html">index.html</a> on GitHub
+        </li>
       </ul>
     </section>
 
@@ -180,9 +181,10 @@ import 'concrete.css'</code></pre>
       <p>Adding a caption to a figure is as simple as it sounds.</p>
       <figure>
         <img alt="Placeholder" src="https://picsum.photos/640/480?grayscale">
-        <figcaption>This is the right-aligned caption for the figure. This example is very long to demonstrate at least one line-break.</figcaption>
-      </figure>      
-    </section>    
+        <figcaption>This is the right-aligned caption for the figure. This example is very long to demonstrate at least
+          one line-break.</figcaption>
+      </figure>
+    </section>
 
     <section>
       <h2>Lists</h2>


### PR DESCRIPTION
I realized concrete is missing styles for `<figure>` and `<figcaption>`, so I added these. Figure contains a full-width image, a right-aligned figure caption in smaller text and a properly spaced bottom border. The bottom border is copied from `<blockquote>`'s left border.

I tried to mimic concrete's design and code style. **Please feel free to change as you see fit.**

Preview images:

**figure and figcaption in dark mode**
![figure-dark](https://github.com/louismerlin/concrete.css/assets/434451/5f3c5df0-499c-4be7-b9dd-1754120b36fc)

**figure and figcaption in light mode**
![figure-light](https://github.com/louismerlin/concrete.css/assets/434451/4549df5e-1a3c-4972-8aac-544b40ef76ba)

Further resources:

[figure in MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)